### PR TITLE
TPNL-375: Removed MapBox due to credit card issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,15 @@ _It is something like a test_, but there are some important differences:
 ## The exercise
 
 The exercise consists of 3 parts in which you use the dataset you can find at [data/cameras-defb.csv](data/cameras-defb.csv).
-You can chose a language and tech stack of your own choice (we are most familiar with C#, JavaScript, PHP, Java).
+You can chose a language and tech stack of your own choice (we are mostly familiar with C#, JavaScript).
 
 ## CLI
 
-Make a program or script that allows the use to search through a CLI a part of the camera _name_, for example:
+Make a program that allows the use to search through a CLI a part of the camera _name_, for example:
 
 ```sh
-# call PHP via CLI
-php search.php --name Neude
-
-# Or if you used .NET Core
+#.NET Core
 dotnet Search --name Neude
-
-# Etc.
 ```
 
 Expected output:
@@ -66,7 +61,7 @@ The spreading of the data needs to follow the following rules based on the `numb
 The second part consists of showing the camera locations as markers on a map. 
 
 Show _all_ cameras in the `div` with id _map_ in the given [code/index.html](code/index.html).
-You can use your preferred Map-tool, but if you don't have a preference, then we suggest that you look at using a combi of [Leaflet JavaScript library](https://leafletjs.com/examples/quick-start/) with the map pictures via a [free MapBox account](https://www.mapbox.com/studio/account/tokens/) (which uses OpenStreetMap). In that case, [the coordinates 52.0914 by 5.1115 will give you a centered view of Utrecht](https://www.openstreetmap.org/#map=14/52.0914/5.1115).
+You can use your preferred Map-tool, but if you don't have a preference, then we suggest that you look at using a combi of [Leaflet JavaScript library](https://leafletjs.com/examples/quick-start/) with the map pictures via OpenStreetMap (Leaflet uses OpenStreetMap). In that case, [the coordinates 52.0914 by 5.1115 will give you a centered view of Utrecht](https://www.openstreetmap.org/#map=14/52.0914/5.1115).
 
 ## Wut? Open Source?!
 


### PR DESCRIPTION
The map box plugin is asking candidates to enter in their credit card details in order to get a trial license. This PR removes the need to create or use MapBox (although it still remains an option for the applicant). The test can now be done using Leaflet only.